### PR TITLE
AO-790 - Metrics b2find - showGroupEnes produces an UNKNOWN state

### DIFF
--- a/checkB2FIND.py
+++ b/checkB2FIND.py
@@ -152,7 +152,7 @@ def checkProbes(args):
 
             elif probe == 'ShowGroupENES':
                 action = 'organization_show'
-                data_dict = {'id': 'enes'}
+                data_dict = {'id': 'darus'}
 
             actionreq = ckanapi3act + action
 


### PR DESCRIPTION
Updated the name of the group to check from enes to darus. This is based on a request from the bfind team.